### PR TITLE
Setup validations for resource

### DIFF
--- a/internal/provider/resource_repository.go
+++ b/internal/provider/resource_repository.go
@@ -182,7 +182,7 @@ func (r *RepositoryResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[a-zA-Z0-9]([-.a-zA-Z0-9]*[a-zA-Z0-9])?$`),
+						regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*$`),
 						"Name must only contain alphanumeric characters, '.', or '-', and must start and end with an alphanumeric character",
 					),
 				},


### PR DESCRIPTION
This fixes the bug #11, but we should start adding validations to all resources - nothing worse than running a full TF apply for it to not catch the validation error till an api call