### PR TITLE
Fix StandardRegistry name for RAM

### DIFF
--- a/internal/pkg/hubclient/client_organization.go
+++ b/internal/pkg/hubclient/client_organization.go
@@ -105,7 +105,7 @@ type OrgSettingRegistryAccessManagement struct {
 }
 
 const (
-	StandardRegistryDocker = "Docker"
+	StandardRegistryDocker = "DockerHub"
 )
 
 type RegistryAccessManagementStandardRegistry struct {


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://github.com/docker/terraform-provider-docker/blob/main/CONTRIBUTING.md#making-code-contributions/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This got undone as part of our re-name in this provider :sweat_smile:

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #32

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccOrgSetting
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -run='TestAccOrgSetting'  -timeout 120m
?       github.com/docker/terraform-provider-docker     [no test files]
?       github.com/docker/terraform-provider-docker/internal/pkg/hubclient      [no test files]
?       github.com/docker/terraform-provider-docker/internal/pkg/repositoryutils        [no test files]
=== RUN   TestAccOrgSettingImageAccessManagement
--- PASS: TestAccOrgSettingImageAccessManagement (4.38s)
=== RUN   TestAccOrgSettingRegistryAccessManagement
--- PASS: TestAccOrgSettingRegistryAccessManagement (5.94s)
PASS
ok      github.com/docker/terraform-provider-docker/internal/provider   10.859s
```
