### PR TITLE
hubclient: assorted api improvements

### DIFF
--- a/examples/load-test/main.tf
+++ b/examples/load-test/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "docker" {
-  host = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }
 
 # Variables to create variations

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "docker" {
-  host = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }
 
 # Resources Demo

--- a/internal/provider/data_source_org_test.go
+++ b/internal/provider/data_source_org_test.go
@@ -24,7 +24,7 @@ func TestOrgDataSource(t *testing.T) {
 
 const testOrgExampleDataSourceConfig = `
 provider "docker" {
-  host = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }
 data "docker_org" "test" {
   org_name = "dockerhackathon"

--- a/internal/provider/data_source_repositories_test.go
+++ b/internal/provider/data_source_repositories_test.go
@@ -26,7 +26,7 @@ func TestAccRepositoriesDataSource(t *testing.T) {
 func testReposExampleDataSourceConfig() string {
 	return `
 provider "docker" {
-  host = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }
 
 data "docker_hub_repositories" "test" {

--- a/internal/provider/data_source_repository_test.go
+++ b/internal/provider/data_source_repository_test.go
@@ -24,7 +24,7 @@ func TestAccRepositoryDataSource(t *testing.T) {
 
 const testAccExampleDataSourceConfig = `
 provider "docker" {
-  host = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }
 data "docker_hub_repository" "test" {
   namespace = "ryanhristovski"

--- a/internal/provider/resource_access_token_test.go
+++ b/internal/provider/resource_access_token_test.go
@@ -40,7 +40,7 @@ func TestAccessTokenResource(t *testing.T) {
 
 const testAccessTokenResourceConfig = `
 provider "docker" {
-  host     = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }
 
 resource "docker_access_token" "test" {

--- a/internal/provider/resource_org_member_test.go
+++ b/internal/provider/resource_org_member_test.go
@@ -34,6 +34,7 @@ func TestAccOrgMemberResource(t *testing.T) {
 func testOrgMemberResourceConfig() string {
 	return `
 provider "docker" {
+  host = "hub-stage.docker.com"
 }
 
 resource "docker_org_member" "test" {

--- a/internal/provider/resource_org_setting_image_access_management_test.go
+++ b/internal/provider/resource_org_setting_image_access_management_test.go
@@ -66,7 +66,7 @@ func TestAccOrgSettingImageAccessManagement(t *testing.T) {
 
 const testAccOrgSettingImageAccessManagementBase = `
 provider "docker" {
-  host = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }`
 
 func testAccOrgSettingImageAccessManagement(orgName string, enabled, allowOfficialImages, allowVerifiedPublishers bool) string {

--- a/internal/provider/resource_org_setting_registry_access_management_test.go
+++ b/internal/provider/resource_org_setting_registry_access_management_test.go
@@ -109,7 +109,7 @@ func TestAccOrgSettingRegistryAccessManagement(t *testing.T) {
 
 const testAccOrgSettingRegistryAccessManagementBase = `
 provider "docker" {
-  host = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }`
 
 func testAccOrgSettingRegistryAccessManagementCustomRegistry(orgName string, enabled, allowDocker bool, custom hubclient.RegistryAccessManagementCustomRegistry) string {

--- a/internal/provider/resource_org_team_test.go
+++ b/internal/provider/resource_org_team_test.go
@@ -79,7 +79,7 @@ func TestAccOrgTeamResource(t *testing.T) {
 
 const testAccOrgTeamResourceBase = `
 provider "docker" {
-  host = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }
 `
 

--- a/internal/provider/resource_repository_team_permission_test.go
+++ b/internal/provider/resource_repository_team_permission_test.go
@@ -61,7 +61,7 @@ func TestAccRepositoryTeamPermission(t *testing.T) {
 func testAccRepositoryTeamPermissionBase(orgName, teamName, repoName string) string {
 	return fmt.Sprintf(`
 provider "docker" {
-  host = "https://hub-stage.docker.com/v2"
+  host = "hub-stage.docker.com"
 }
 
 resource "docker_org_team" "test" {


### PR DESCRIPTION
- default to hub.docker.com, not hub-stage.docker.com
- the host attribute should be a host, not a URL
- return more informative errors when jwt exchange fails

Signed-off-by: Nick Santos <nick.santos@docker.com>
