### PR TITLE
Remove hardcoded provider in acceptance tests

### DIFF
--- a/.github/workflows/acctest.yaml
+++ b/.github/workflows/acctest.yaml
@@ -3,16 +3,21 @@ name: Acceptance Tests
 on:
   workflow_dispatch:
     inputs: 
-      terraform-version:
-        description: 'Terraform version'
-        type: string
-        required: false
-        default: '1.9.*'
       ref: 
         description: 'The ref to checkout e.g the SHA of a fork in PR'
         type: string
         required: false
         default: 'main'
+      tests: 
+        description: 'The TESTS pattern to supply to `make testacc`. Default is all tests.'
+        type: string
+        required: false
+        default: 'TestAcc'
+      terraform-version:
+        description: 'Terraform version'
+        type: string
+        required: false
+        default: '1.9.*'
 
 jobs:
   acctest:
@@ -35,9 +40,10 @@ jobs:
           terraform_wrapper: false
 
       - run: |
-          go test ./... -run=TestAcc -v
+          make testacc TESTS='${{ inputs.tests }}'
         env:
           DOCKER_USERNAME: "${{ vars.DOCKER_USERNAME }}"
           DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+          DOCKER_HUB_HOST: "hub-stage.docker.com"
           TF_ACC: "1"
         timeout-minutes: 30

--- a/internal/provider/data_source_org_test.go
+++ b/internal/provider/data_source_org_test.go
@@ -27,9 +27,6 @@ func TestOrgDataSource(t *testing.T) {
 
 func testOrgExampleDataSourceConfig(org string) string {
 	return fmt.Sprintf(`
-provider "docker" {
-  host = "hub-stage.docker.com"
-}
 data "docker_org" "test" {
   org_name = "%[1]s"
 }`, org)

--- a/internal/provider/data_source_repositories_test.go
+++ b/internal/provider/data_source_repositories_test.go
@@ -25,10 +25,6 @@ func TestAccRepositoriesDataSource(t *testing.T) {
 
 func testReposExampleDataSourceConfig() string {
 	return `
-provider "docker" {
-  host = "hub-stage.docker.com"
-}
-
 data "docker_hub_repositories" "test" {
   namespace         = "` + os.Getenv("DOCKER_USERNAME") + `"
   max_number_results = 10

--- a/internal/provider/data_source_repository_test.go
+++ b/internal/provider/data_source_repository_test.go
@@ -23,9 +23,6 @@ func TestAccRepositoryDataSource(t *testing.T) {
 }
 
 const testAccExampleDataSourceConfig = `
-provider "docker" {
-  host = "hub-stage.docker.com"
-}
 data "docker_hub_repository" "test" {
   namespace = "ryanhristovski"
   name = "data-source-example"

--- a/internal/provider/resource_access_token_test.go
+++ b/internal/provider/resource_access_token_test.go
@@ -39,10 +39,6 @@ func TestAccessTokenResource(t *testing.T) {
 }
 
 const testAccessTokenResourceConfig = `
-provider "docker" {
-  host = "hub-stage.docker.com"
-}
-
 resource "docker_access_token" "test" {
   token_label = "test-label"
   scopes      = ["repo:read", "repo:write"]

--- a/internal/provider/resource_org_member_test.go
+++ b/internal/provider/resource_org_member_test.go
@@ -37,10 +37,6 @@ func TestAccOrgMemberResource(t *testing.T) {
 
 func testOrgMemberResourceConfig(org string, team string) string {
 	return fmt.Sprintf(`
-provider "docker" {
-  host = "hub-stage.docker.com"
-}
-
 resource "docker_org_team" "testing" {
   org_name         = "%[1]s"
   team_name        = "%[2]s"

--- a/internal/provider/resource_org_setting_image_access_management_test.go
+++ b/internal/provider/resource_org_setting_image_access_management_test.go
@@ -59,26 +59,19 @@ func TestAccOrgSettingImageAccessManagement(t *testing.T) {
 			},
 			{
 				// delete
-				Config: testAccOrgSettingImageAccessManagementBase,
+				Config: " ",
 			},
 		},
 	})
 }
 
-const testAccOrgSettingImageAccessManagementBase = `
-provider "docker" {
-  host = "hub-stage.docker.com"
-}`
-
 func testAccOrgSettingImageAccessManagement(orgName string, enabled, allowOfficialImages, allowVerifiedPublishers bool) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "docker_org_setting_image_access_management" "test" {
-  org_name                  = "%[2]s"
-  enabled                   = %[3]t
-  allow_official_images     = %[4]t
-  allow_verified_publishers = %[5]t
+  org_name                  = "%[1]s"
+  enabled                   = %[2]t
+  allow_official_images     = %[3]t
+  allow_verified_publishers = %[4]t
 }
-`, testAccOrgSettingImageAccessManagementBase, orgName, enabled, allowOfficialImages, allowVerifiedPublishers)
+`, orgName, enabled, allowOfficialImages, allowVerifiedPublishers)
 }

--- a/internal/provider/resource_org_setting_registry_access_management_test.go
+++ b/internal/provider/resource_org_setting_registry_access_management_test.go
@@ -102,70 +102,53 @@ func TestAccOrgSettingRegistryAccessManagement(t *testing.T) {
 			},
 			{
 				// delete
-				Config: testAccOrgSettingRegistryAccessManagementBase,
+				Config: " ",
 			},
 		},
 	})
 }
 
-const testAccOrgSettingRegistryAccessManagementBase = `
-provider "docker" {
-  host = "hub-stage.docker.com"
-}`
-
 func testAccOrgSettingRegistryAccessManagementCustomRegistry(orgName string, enabled, allowDocker bool, custom hubclient.RegistryAccessManagementCustomRegistry) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "docker_org_setting_registry_access_management" "test" {
-  org_name                     = "%[2]s"
-  enabled                      = %[3]t
+  org_name                     = "%[1]s"
+  enabled                      = %[2]t
   standard_registry_docker_hub = {
-    allowed = %[4]t
+    allowed = %[3]t
   }
   custom_registries = [
     {
-	  address       = "%[5]s",
-	  friendly_name = "%[6]s",
-	  allowed       = %[7]t
+	  address       = "%[4]s",
+	  friendly_name = "%[5]s",
+	  allowed       = %[6]t
   	}
   ]
 }
-`, testAccOrgSettingRegistryAccessManagementBase,
-		orgName,
-		enabled,
-		allowDocker,
-		custom.Address,
-		custom.FriendlyName,
-		custom.Allowed,
-	)
+`, orgName, enabled, allowDocker, custom.Address, custom.FriendlyName, custom.Allowed)
 }
 
 func testAccOrgSettingRegistryAccessManagementMultipleCustomRegistries(orgName string, enabled, allowDocker bool, custom1 hubclient.RegistryAccessManagementCustomRegistry, custom2 hubclient.RegistryAccessManagementCustomRegistry) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "docker_org_setting_registry_access_management" "test" {
-  org_name                     = "%[2]s"
-  enabled                      = %[3]t
+  org_name                     = "%[1]s"
+  enabled                      = %[2]t
   standard_registry_docker_hub = {
-    allowed = %[4]t
+    allowed = %[3]t
   }
   custom_registries = [
     {
-	  address       = "%[5]s",
-	  friendly_name = "%[6]s",
-	  allowed       = %[7]t
+	  address       = "%[4]s",
+	  friendly_name = "%[5]s",
+	  allowed       = %[6]t
   	},
 	{
-	  address       = "%[8]s",
-	  friendly_name = "%[9]s",
-	  allowed       = %[10]t
+	  address       = "%[7]s",
+	  friendly_name = "%[8]s",
+	  allowed       = %[9]t
   	}
   ]
 }
 `,
-		testAccOrgSettingRegistryAccessManagementBase,
 		orgName,
 		enabled,
 		allowDocker,
@@ -180,15 +163,13 @@ resource "docker_org_setting_registry_access_management" "test" {
 
 func testAccOrgSettingRegistryAccessManagementNoCustomRegistry(orgName string, enabled, allowDocker bool) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "docker_org_setting_registry_access_management" "test" {
-  org_name                     = "%[2]s"
-  enabled                      = %[3]t
+  org_name                     = "%[1]s"
+  enabled                      = %[2]t
   standard_registry_docker_hub = {
-    allowed = %[4]t
+    allowed = %[3]t
   }
   custom_registries = []
 }
-`, testAccOrgSettingRegistryAccessManagementBase, orgName, enabled, allowDocker)
+`, orgName, enabled, allowDocker)
 }

--- a/internal/provider/resource_org_team_test.go
+++ b/internal/provider/resource_org_team_test.go
@@ -62,7 +62,7 @@ func TestAccOrgTeamResource(t *testing.T) {
 			},
 			{
 				// delete
-				Config: testAccOrgTeamResourceBase,
+				Config: " ",
 			},
 			{
 				// create no description
@@ -78,31 +78,23 @@ func TestAccOrgTeamResource(t *testing.T) {
 	})
 }
 
-const testAccOrgTeamResourceBase = `
-provider "docker" {
-  host = "hub-stage.docker.com"
-}
-`
-
 func testAccOrgTeamResource(orgName, teamName, teamDesc string) string {
 	return fmt.Sprintf(`
-%s
 resource "docker_org_team" "testing" {
   org_name         = "%s"
   team_name        = "%s"
   team_description = "%s"
 }
-`, testAccOrgTeamResourceBase, orgName, teamName, teamDesc)
+`, orgName, teamName, teamDesc)
 }
 
 func testAccOrgTeamResourceNoDescription(orgName, teamName string) string {
 	return fmt.Sprintf(`
-%s
 resource "docker_org_team" "testing" {
   org_name         = "%s"
   team_name        = "%s"
 }
-`, testAccOrgTeamResourceBase, orgName, teamName)
+`, orgName, teamName)
 }
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyz1234567890")

--- a/internal/provider/resource_repository_team_permission_test.go
+++ b/internal/provider/resource_repository_team_permission_test.go
@@ -61,10 +61,6 @@ func TestAccRepositoryTeamPermission(t *testing.T) {
 
 func testAccRepositoryTeamPermissionBase(orgName, teamName, repoName string) string {
 	return fmt.Sprintf(`
-provider "docker" {
-  host = "hub-stage.docker.com"
-}
-
 resource "docker_org_team" "test" {
   org_name         = "%[1]s"
   team_name        = "%[2]s"

--- a/internal/provider/resource_repository_test.go
+++ b/internal/provider/resource_repository_test.go
@@ -50,10 +50,6 @@ func TestAccRepositoryResource(t *testing.T) {
 
 func testRepositoryResourceConfig(namespace, name string) string {
 	return fmt.Sprintf(`
-provider "docker" {
-  host = "hub-stage.docker.com"
-}
-
 resource "docker_hub_repository" "test" {
   name            = "%[2]s"
   namespace       = "%[1]s"
@@ -64,10 +60,6 @@ resource "docker_hub_repository" "test" {
 
 func testRepositoryResourceConfigUpdated(namespace, name string) string {
 	return fmt.Sprintf(`
-provider "docker" {
-  host = "hub-stage.docker.com"
-}
-
 resource "docker_hub_repository" "test" {
   name            = "%[2]s"
   namespace       = "%[1]s"


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://github.com/docker/terraform-provider-docker/blob/main/CONTRIBUTING.md#making-code-contributions/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This allows us to use user supplied environment variable to control. Most acceptance tests from end users will against prod host.

Also allow us to supply test pattern in workflow_dispatch.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
╰─ DOCKER_HUB_HOST=hub-stage.docker.com make testacc TESTS='TestAcc'
TF_ACC=1 go test ./... -v -count 1 -parallel 20 -timeout 120m -run='TestAcc' 
?       github.com/docker/terraform-provider-docker     [no test files]
?       github.com/docker/terraform-provider-docker/internal/envvar     [no test files]
?       github.com/docker/terraform-provider-docker/internal/pkg/hubclient      [no test files]
?       github.com/docker/terraform-provider-docker/internal/pkg/repositoryutils        [no test files]
=== RUN   TestAccRepositoriesDataSource
--- PASS: TestAccRepositoriesDataSource (1.45s)
=== RUN   TestAccRepositoryDataSource
--- PASS: TestAccRepositoryDataSource (1.07s)
=== RUN   TestAccessTokenResource
--- PASS: TestAccessTokenResource (1.47s)
=== RUN   TestAccOrgMemberResource
--- PASS: TestAccOrgMemberResource (1.43s)
=== RUN   TestAccOrgSettingImageAccessManagement
--- PASS: TestAccOrgSettingImageAccessManagement (3.91s)
=== RUN   TestAccOrgSettingRegistryAccessManagement
--- PASS: TestAccOrgSettingRegistryAccessManagement (6.30s)
=== RUN   TestAccOrgTeamResource
--- PASS: TestAccOrgTeamResource (5.15s)
=== RUN   TestAccRepositoryTeamPermission
--- PASS: TestAccRepositoryTeamPermission (3.97s)
=== RUN   TestAccRepositoryResource
--- PASS: TestAccRepositoryResource (2.37s)
PASS
ok      github.com/docker/terraform-provider-docker/internal/provider 

...
```
