### PR TITLE
Use ACCTEST variables in acceptance test CI

### DIFF
--- a/.github/workflows/acctest.yaml
+++ b/.github/workflows/acctest.yaml
@@ -39,16 +39,11 @@ jobs:
           terraform_version: ${{ inputs.terraform-version }}
           terraform_wrapper: false
 
-      - uses: docker/login-action@v2
-        with:
-          username: ${{ vars.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          registry: index-stage.docker.io
-
       - run: |
           make testacc TESTS='${{ inputs.tests }}'
         env:
-          DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
-          DOCKER_HUB_HOST: "hub-stage.docker.com"
+          DOCKER_USERNAME: ${{ secrets.ACCTEST_DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.ACCTEST_DOCKER_PASSWORD }}
+          DOCKER_HUB_HOST: ${{ secrets.ACCTEST_HUB_HOST }}
           TF_ACC: "1"
         timeout-minutes: 30

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,10 +22,10 @@ import (
 
 var hostRegexp = regexp.MustCompile(`^[a-zA-Z0-9:.-]+$`)
 
-const dockerHubConfigfileKey = "https://index.docker.io/v1/"
-const dockerHubStageConfigfileKey = "index-stage.docker.io"
-const dockerHubHost = "hub.docker.com"
-const dockerHubStageHost = "hub-stage.docker.com"
+const (
+	dockerHubConfigfileKey = "https://index.docker.io/v1/"
+	dockerHubHost          = "hub.docker.com"
+)
 
 // Ensure DockerProvider satisfies various provider interfaces.
 var (
@@ -128,8 +128,6 @@ func (p *DockerProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		configfileKey := host
 		if host == dockerHubHost {
 			configfileKey = dockerHubConfigfileKey
-		} else if host == dockerHubStageHost {
-			configfileKey = dockerHubStageConfigfileKey
 		}
 
 		// Use the getUserCreds function to retrieve credentials from Docker config


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://github.com/docker/terraform-provider-docker/blob/main/CONTRIBUTING.md#making-code-contributions/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX
?       github.com/docker/terraform-provider-docker     [no test files]
?       github.com/docker/terraform-provider-docker/internal/envvar     [no test files]
?       github.com/docker/terraform-provider-docker/internal/hubclient  [no test files]
?       github.com/docker/terraform-provider-docker/internal/repositoryutils    [no test files]
?       github.com/docker/terraform-provider-docker/tools       [no test files]
=== RUN   TestAccOrgTeamDataSource
--- PASS: TestAccOrgTeamDataSource (3.49s)
=== RUN   TestOrgDataSource
--- PASS: TestOrgDataSource (0.94s)
=== RUN   TestAccRepositoriesDataSource
--- PASS: TestAccRepositoriesDataSource (0.92s)
=== RUN   TestAccRepositoryDataSource
--- PASS: TestAccRepositoryDataSource (1.17s)
=== RUN   TestAccessTokenResource
--- PASS: TestAccessTokenResource (1.36s)
=== RUN   TestAccOrgMemberResource
--- PASS: TestAccOrgMemberResource (1.55s)
=== RUN   TestAccOrgSettingImageAccessManagement
--- PASS: TestAccOrgSettingImageAccessManagement (4.29s)
=== RUN   TestAccOrgSettingRegistryAccessManagement
--- PASS: TestAccOrgSettingRegistryAccessManagement (7.47s)
=== RUN   TestAccOrgTeamMember
--- PASS: TestAccOrgTeamMember (2.52s)
=== RUN   TestAccOrgTeamResource
--- PASS: TestAccOrgTeamResource (5.82s)
=== RUN   TestAccRepositoryTeamPermission
--- PASS: TestAccRepositoryTeamPermission (5.05s)
=== RUN   TestAccRepositoryResource
...
```
