### PR TITLE
Improve error message on repository name validator

### DIFF
--- a/internal/provider/resource_repository.go
+++ b/internal/provider/resource_repository.go
@@ -205,7 +205,7 @@ func (r *RepositoryResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*$`),
-						"Name must only contain alphanumeric characters, '.', or '-', and must start and end with an alphanumeric character",
+						"Name must only contain lowercase alphanumeric characters, '.', or '-', and must start and end with a lowercase alphanumeric character",
 					),
 				},
 			},


### PR DESCRIPTION
We enforce lowercase as well but this was not reflected in error message.

Closes https://github.com/docker/terraform-provider-docker/issues/64

<!---
See what makes a good Pull Request at: https://github.com/docker/terraform-provider-docker/blob/main/CONTRIBUTING.md#making-code-contributions/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX

...
```
