### PR TITLE
docker_org_member: revamp the model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Ignore Terraform state files
 *.tfstate
 *.tfstate.backup
+
+# Store acceptance testing secrets in .env
+.env

--- a/docs/resources/org_member.md
+++ b/docs/resources/org_member.md
@@ -3,31 +3,69 @@
 page_title: "docker_org_member Resource - docker"
 subcategory: ""
 description: |-
-  Manages team members associated with an organization.
+  Manages members associated with an organization.
   ~> Note Only available when authenticated with a username and password as an owner of the org.
+  When a member is added to an organization, they don't have access to the
+  organization's repositories until they accept the invitation. The invitation is
+  sent to the email address associated with the user's Docker ID.
   Example Usage
   
   resource "docker_org_member" "example" {
   	org_name = "org_name"
   	role     = "member"
-  	username = "orgmember@docker.com"
+  	email    = "orgmember@docker.com"
+  }
+  
+  Import State
+  
+  
+  import {
+    id = "org-name/user-name"
+    to = docker_org_member.example
+  }
+  
+  resource "docker_org_member" "example" {
+  	org_name  = "org-name"
+  	role      = "member"
+  	user_name = "user-name"
   }
 ---
 
 # docker_org_member (Resource)
 
-Manages team members associated with an organization.
+Manages members associated with an organization.
 
 ~> **Note** Only available when authenticated with a username and password as an owner of the org.
 
+When a member is added to an organization, they don't have access to the
+organization's repositories until they accept the invitation. The invitation is
+sent to the email address associated with the user's Docker ID.
+
 ## Example Usage
-	
+
 ```hcl
 resource "docker_org_member" "example" {
 	org_name = "org_name"
 	role     = "member"
-	username = "orgmember@docker.com"
+	email    = "orgmember@docker.com"
 }
+```
+
+## Import State
+
+```hcl
+
+import {
+  id = "org-name/user-name"
+  to = docker_org_member.example
+}
+
+resource "docker_org_member" "example" {
+	org_name  = "org-name"
+	role      = "member"
+	user_name = "user-name"
+}
+
 ```
 
 
@@ -39,12 +77,12 @@ resource "docker_org_member" "example" {
 
 - `org_name` (String) Organization name
 - `role` (String) Role assigned to the user within the organization (e.g., 'member', 'editor', 'owner').
-- `user_name` (String) User name (email) of the member being associated with the team
 
 ### Optional
 
-- `team_name` (String) Team name within the organization
+- `email` (String) Email of the member. Either user_name or email must be specified.
+- `user_name` (String) User name of the member. Either user_name or email must be specified.
 
 ### Read-Only
 
-- `invite_id` (String) The ID of the invite. Used for managing the , especially for deletion.
+- `invite_id` (String) The ID of the invite. Used for managing membership invites that haven't been accepted yet.

--- a/internal/hubclient/client_organization.go
+++ b/internal/hubclient/client_organization.go
@@ -106,6 +106,10 @@ type OrgInvite struct {
 	CreatedAt       string `json:"created_at"`
 }
 
+type OrgInvitesListResponse struct {
+	Data []OrgInvite `json:"data"`
+}
+
 type OrgSettingImageAccessManagement struct {
 	RestrictedImages ImageAccessManagementRestrictedImages `json:"restricted_images"`
 }
@@ -284,10 +288,15 @@ func (c *Client) SetOrgSettingRegistryAccessManagement(ctx context.Context, orgN
 	return c.GetOrgSettingRegistryAccessManagement(ctx, orgName)
 }
 
-func (c *Client) InviteOrgMember(ctx context.Context, orgName, teamName, role string, invitees []string, dryRun bool) (OrgInviteResponse, error) {
+func (c *Client) ListOrgInvites(ctx context.Context, orgName string) ([]OrgInvite, error) {
+	var invites OrgInvitesListResponse
+	err := c.sendRequest(ctx, "GET", fmt.Sprintf("/orgs/%s/invites", orgName), nil, &invites)
+	return invites.Data, err
+}
+
+func (c *Client) InviteOrgMember(ctx context.Context, orgName, role string, invitees []string, dryRun bool) (OrgInviteResponse, error) {
 	inviteRequest := OrgMemberRequest{
 		Org:      orgName,
-		Team:     teamName,
 		Invitees: invitees,
 		Role:     role,
 		DryRun:   dryRun,


### PR DESCRIPTION
- the invite API lets you send invites by username and email
- before this PR, docker_org_member was designed to match
  the invite API
- In practice, this made it impossible to implement
  import behavior.
- now, we model docker_org_member closer to how
  the list org members api represents things

Signed-off-by: Nick Santos <nick.santos@docker.com>
