### PR TITLE
docs: remove hub prefix from datasources

### DIFF
--- a/docs/data-sources/access_token.md
+++ b/docs/data-sources/access_token.md
@@ -6,17 +6,17 @@ description: |-
   Retrieves details of a specific Docker Hub access token by its UUID.
   Example Usage
   
-  data "docker_hub_access_token" "example" {
+  data "docker_access_token" "example" {
   	uuid = "123e4567-e89b-12d3-a456-426614174000"
   }
   
   output "access_token_details" {
   	value = {
-  	label       = data.docker_hub_access_token.example.token_label
-  	scopes      = data.docker_hub_access_token.example.scopes
-  	created_at  = data.docker_hub_access_token.example.created_at
-  	last_used   = data.docker_hub_access_token.example.last_used
-  	is_active   = data.docker_hub_access_token.example.is_active
+  	label       = data.docker_access_token.example.token_label
+  	scopes      = data.docker_access_token.example.scopes
+  	created_at  = data.docker_access_token.example.created_at
+  	last_used   = data.docker_access_token.example.last_used
+  	is_active   = data.docker_access_token.example.is_active
     }
   }
 ---
@@ -28,17 +28,17 @@ Retrieves details of a specific Docker Hub access token by its UUID.
 ## Example Usage
 
 ```hcl
-data "docker_hub_access_token" "example" {
+data "docker_access_token" "example" {
 	uuid = "123e4567-e89b-12d3-a456-426614174000"
 }
 
 output "access_token_details" {
 	value = {
-	label       = data.docker_hub_access_token.example.token_label
-	scopes      = data.docker_hub_access_token.example.scopes
-	created_at  = data.docker_hub_access_token.example.created_at
-	last_used   = data.docker_hub_access_token.example.last_used
-	is_active   = data.docker_hub_access_token.example.is_active
+	label       = data.docker_access_token.example.token_label
+	scopes      = data.docker_access_token.example.scopes
+	created_at  = data.docker_access_token.example.created_at
+	last_used   = data.docker_access_token.example.last_used
+	is_active   = data.docker_access_token.example.is_active
   }
 }
 ```

--- a/docs/data-sources/access_tokens.md
+++ b/docs/data-sources/access_tokens.md
@@ -6,10 +6,10 @@ description: |-
   Retrieves the list of Docker Hub access tokens associated with the authenticated user.
   Example Usage
   
-  data "docker_hub_access_tokens" "example" {}
+  data "docker_access_tokens" "example" {}
   
   output "access_token_uuids" {
-  	value = data.docker_hub_access_tokens.example.uuids
+  	value = data.docker_access_tokens.example.uuids
   }
 ---
 
@@ -20,10 +20,10 @@ Retrieves the list of Docker Hub access tokens associated with the authenticated
 ## Example Usage
 
 ```hcl
-data "docker_hub_access_tokens" "example" {}
+data "docker_access_tokens" "example" {}
 
 output "access_token_uuids" {
-	value = data.docker_hub_access_tokens.example.uuids
+	value = data.docker_access_tokens.example.uuids
 }
 ```
 

--- a/docs/data-sources/login.md
+++ b/docs/data-sources/login.md
@@ -6,10 +6,10 @@ description: |-
   Reads the current login information.
   Example Usage
   
-  data "docker_hub_login" "current" {}
+  data "docker_login" "current" {}
   
   output "current_user" {
-  	value = data.docker_hub_login.current.username
+  	value = data.docker_login.current.username
   }
 ---
 
@@ -20,10 +20,10 @@ Reads the current login information.
 ## Example Usage
 
 ```hcl
-data "docker_hub_login" "current" {}
+data "docker_login" "current" {}
 
 output "current_user" {
-	value = data.docker_hub_login.current.username
+	value = data.docker_login.current.username
 }
 ```
 

--- a/docs/data-sources/org.md
+++ b/docs/data-sources/org.md
@@ -7,17 +7,17 @@ description: |-
   ~> Note: This data source is only available when authenticated with a username and password.
   Example Usage
   
-  data "docker_hub_org" "example" {
+  data "docker_org" "example" {
   	org_name = "my-organization"
   }
   
   output "organization_details" {
     value = {
-  	id          = data.docker_hub_org.example.id
-  	full_name   = data.docker_hub_org.example.full_name
-  	location    = data.docker_hub_org.example.location
-  	company     = data.docker_hub_org.example.company
-  	date_joined = data.docker_hub_org.example.date_joined
+  	id          = data.docker_org.example.id
+  	full_name   = data.docker_org.example.full_name
+  	location    = data.docker_org.example.location
+  	company     = data.docker_org.example.company
+  	date_joined = data.docker_org.example.date_joined
     }
   }
 ---
@@ -31,17 +31,17 @@ Reads properties of a Docker Hub organization.
 ## Example Usage
 
 ```hcl
-data "docker_hub_org" "example" {
+data "docker_org" "example" {
 	org_name = "my-organization"
 }
 
 output "organization_details" {
   value = {
-	id          = data.docker_hub_org.example.id
-	full_name   = data.docker_hub_org.example.full_name
-	location    = data.docker_hub_org.example.location
-	company     = data.docker_hub_org.example.company
-	date_joined = data.docker_hub_org.example.date_joined
+	id          = data.docker_org.example.id
+	full_name   = data.docker_org.example.full_name
+	location    = data.docker_org.example.location
+	company     = data.docker_org.example.company
+	date_joined = data.docker_org.example.date_joined
   }
 }
 ```

--- a/docs/data-sources/org_team.md
+++ b/docs/data-sources/org_team.md
@@ -7,17 +7,17 @@ description: |-
   ~> Note: This data source is only available when authenticated with a username and password.
   Example Usage
   
-  data "docker_hub_org_team" "example" {
+  data "docker_org_team" "example" {
   	org_name  = "my-organization"
   	team_name = "dev-team"
   }
   
   output "team_info" {
   value = {
-  	id           = data.docker_hub_org_team.example.id
-  	uuid         = data.docker_hub_org_team.example.uuid
-  	description  = data.docker_hub_org_team.example.description
-  	member_count = data.docker_hub_org_team.example.member_count
+  	id           = data.docker_org_team.example.id
+  	uuid         = data.docker_org_team.example.uuid
+  	description  = data.docker_org_team.example.description
+  	member_count = data.docker_org_team.example.member_count
     }
   }
 ---
@@ -31,17 +31,17 @@ Reads team information within a Docker Hub organization.
 ## Example Usage
 
 ```hcl
-data "docker_hub_org_team" "example" {
+data "docker_org_team" "example" {
 	org_name  = "my-organization"
 	team_name = "dev-team"
 }
 
 output "team_info" {
 value = {
-	id           = data.docker_hub_org_team.example.id
-	uuid         = data.docker_hub_org_team.example.uuid
-	description  = data.docker_hub_org_team.example.description
-	member_count = data.docker_hub_org_team.example.member_count
+	id           = data.docker_org_team.example.id
+	uuid         = data.docker_org_team.example.uuid
+	description  = data.docker_org_team.example.description
+	member_count = data.docker_org_team.example.member_count
   }
 }
 ```

--- a/docs/data-sources/org_team_member.md
+++ b/docs/data-sources/org_team_member.md
@@ -7,17 +7,17 @@ description: |-
   ~> Note: This data source is only available when authenticated with a username and password.
   Example Usage
   
-  data "docker_hub_org_team_member" "example" {
+  data "docker_org_team_member" "example" {
   	org_name  = "my-organization"
   	team_name = "dev-team"
   }
   
   output "team_members" {
-  	value = data.docker_hub_org_team_member.example.members
+  	value = data.docker_org_team_member.example.members
   }
   
   output "team_member_roles" {
-  	value = [for member in data.docker_hub_org_team_member.example.members : { member = member.username, role = member.role }]
+  	value = [for member in data.docker_org_team_member.example.members : { member = member.username, role = member.role }]
   }
   	```
 ---
@@ -31,17 +31,17 @@ Reads team members of a specified team within a Docker Hub organization.
 ## Example Usage
 
 ```hcl
-data "docker_hub_org_team_member" "example" {
+data "docker_org_team_member" "example" {
 	org_name  = "my-organization"
 	team_name = "dev-team"
 }
 
 output "team_members" {
-	value = data.docker_hub_org_team_member.example.members
+	value = data.docker_org_team_member.example.members
 }
 
 output "team_member_roles" {
-	value = [for member in data.docker_hub_org_team_member.example.members : { member = member.username, role = member.role }]
+	value = [for member in data.docker_org_team_member.example.members : { member = member.username, role = member.role }]
 }
 	```
 

--- a/internal/provider/data_source_access_token.go
+++ b/internal/provider/data_source_access_token.go
@@ -64,17 +64,17 @@ func (d *AccessTokenDataSource) Schema(ctx context.Context, req datasource.Schem
 ## Example Usage
 
 ` + "```hcl" + `
-data "docker_hub_access_token" "example" {
+data "docker_access_token" "example" {
 	uuid = "123e4567-e89b-12d3-a456-426614174000"
 }
 
 output "access_token_details" {
 	value = {
-	label       = data.docker_hub_access_token.example.token_label
-	scopes      = data.docker_hub_access_token.example.scopes
-	created_at  = data.docker_hub_access_token.example.created_at
-	last_used   = data.docker_hub_access_token.example.last_used
-	is_active   = data.docker_hub_access_token.example.is_active
+	label       = data.docker_access_token.example.token_label
+	scopes      = data.docker_access_token.example.scopes
+	created_at  = data.docker_access_token.example.created_at
+	last_used   = data.docker_access_token.example.last_used
+	is_active   = data.docker_access_token.example.is_active
   }
 }
 ` + "```" + `

--- a/internal/provider/data_source_access_tokens.go
+++ b/internal/provider/data_source_access_tokens.go
@@ -54,10 +54,10 @@ func (d *AccessTokensDataSource) Schema(ctx context.Context, req datasource.Sche
 ## Example Usage
 
 ` + "```hcl" + `
-data "docker_hub_access_tokens" "example" {}
+data "docker_access_tokens" "example" {}
 
 output "access_token_uuids" {
-	value = data.docker_hub_access_tokens.example.uuids
+	value = data.docker_access_tokens.example.uuids
 }
 ` + "```" + `
 `,

--- a/internal/provider/data_source_login.go
+++ b/internal/provider/data_source_login.go
@@ -54,10 +54,10 @@ func (d *LoginDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 ## Example Usage
 
 ` + "```hcl" + `
-data "docker_hub_login" "current" {}
+data "docker_login" "current" {}
 
 output "current_user" {
-	value = data.docker_hub_login.current.username
+	value = data.docker_login.current.username
 }
 ` + "```" + `
 `,

--- a/internal/provider/data_source_org.go
+++ b/internal/provider/data_source_org.go
@@ -61,17 +61,17 @@ func (d *OrgDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 ## Example Usage
 
 ` + "```hcl" + `
-data "docker_hub_org" "example" {
+data "docker_org" "example" {
 	org_name = "my-organization"
 }
 
 output "organization_details" {
   value = {
-	id          = data.docker_hub_org.example.id
-	full_name   = data.docker_hub_org.example.full_name
-	location    = data.docker_hub_org.example.location
-	company     = data.docker_hub_org.example.company
-	date_joined = data.docker_hub_org.example.date_joined
+	id          = data.docker_org.example.id
+	full_name   = data.docker_org.example.full_name
+	location    = data.docker_org.example.location
+	company     = data.docker_org.example.company
+	date_joined = data.docker_org.example.date_joined
   }
 }
 ` + "```" + `

--- a/internal/provider/data_source_org_team.go
+++ b/internal/provider/data_source_org_team.go
@@ -61,17 +61,17 @@ func (d *OrgTeamDataSource) Schema(ctx context.Context, req datasource.SchemaReq
 ## Example Usage
 
 ` + "```hcl" + `
-data "docker_hub_org_team" "example" {
+data "docker_org_team" "example" {
 	org_name  = "my-organization"
 	team_name = "dev-team"
 }
 
 output "team_info" {
 value = {
-	id           = data.docker_hub_org_team.example.id
-	uuid         = data.docker_hub_org_team.example.uuid
-	description  = data.docker_hub_org_team.example.description
-	member_count = data.docker_hub_org_team.example.member_count
+	id           = data.docker_org_team.example.id
+	uuid         = data.docker_org_team.example.uuid
+	description  = data.docker_org_team.example.description
+	member_count = data.docker_org_team.example.member_count
   }
 }
 ` + "```" + `

--- a/internal/provider/data_source_org_team_member.go
+++ b/internal/provider/data_source_org_team_member.go
@@ -81,17 +81,17 @@ func (d *OrgTeamMemberDataSource) Schema(ctx context.Context, req datasource.Sch
 ## Example Usage
 
 ` + "```hcl" + `
-data "docker_hub_org_team_member" "example" {
+data "docker_org_team_member" "example" {
 	org_name  = "my-organization"
 	team_name = "dev-team"
 }
 
 output "team_members" {
-	value = data.docker_hub_org_team_member.example.members
+	value = data.docker_org_team_member.example.members
 }
 
 output "team_member_roles" {
-	value = [for member in data.docker_hub_org_team_member.example.members : { member = member.username, role = member.role }]
+	value = [for member in data.docker_org_team_member.example.members : { member = member.username, role = member.role }]
 }
 	` + "```" + `
 `,


### PR DESCRIPTION
### Description

Some resources in datasources examples incorrectly used docker_hub_<resource_type> instead of docker_<resource_type>.

This PR change the metadata of resources and regenerate corrected docs

### Relations

N/A

### References

N/A

### Output from Acceptance Testing

I cannot run the acceptance criterias with my free dockerhub account but this only change the doc