### PR TITLE
auth: improve error handling

### DIFF
--- a/internal/hubclient/client.go
+++ b/internal/hubclient/client.go
@@ -44,37 +44,17 @@ type Client struct {
 	maxPageResults int64
 }
 
-type userAgentTransport struct {
-	userAgent string
-	transport http.RoundTripper
-}
-
-func (uat *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", uat.userAgent)
-	return uat.transport.RoundTrip(req)
-}
-
 type Config struct {
-	BaseURL          string
-	TokenProvider    TokenProvider
-	UserAgentVersion string
-	MaxPageResults   int64
+	BaseURL        string
+	TokenProvider  TokenProvider
+	Transport      http.RoundTripper
+	MaxPageResults int64
 }
 
 func NewClient(config Config) *Client {
-	version := config.UserAgentVersion
-	if version == "" {
-		version = "dev"
-	}
-
-	userAgentTransport := &userAgentTransport{
-		userAgent: fmt.Sprintf("terraform-provider-docker/%s", version),
-		transport: http.DefaultTransport,
-	}
-
 	baseClient := &http.Client{
 		Timeout:   time.Minute,
-		Transport: userAgentTransport,
+		Transport: config.Transport,
 	}
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient = baseClient

--- a/internal/hubhttp/transport.go
+++ b/internal/hubhttp/transport.go
@@ -1,0 +1,44 @@
+/*
+   Copyright 2024 Docker Terraform Provider authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package hubhttp
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type userAgentTransport struct {
+	userAgent string
+	transport http.RoundTripper
+}
+
+func (uat *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", uat.userAgent)
+	return uat.transport.RoundTrip(req)
+}
+
+// NewUserAgentTransport creates a RoundTripper that adds a User-Agent header
+func NewUserAgentTransport(version string) http.RoundTripper {
+	if version == "" {
+		version = "dev"
+	}
+
+	return &userAgentTransport{
+		userAgent: fmt.Sprintf("terraform-provider-docker/%s", version),
+		transport: http.DefaultTransport,
+	}
+}


### PR DESCRIPTION
- return the result of a login failure
- use the correct user-agent for auth http requests

Signed-off-by: Nick Santos <nick.santos@docker.com>
