### PR TITLE
hubclient: minor bug fixes

### DIFF
--- a/internal/hubclient/client.go
+++ b/internal/hubclient/client.go
@@ -96,6 +96,12 @@ func (c *Client) sendRequest(ctx context.Context, method string, url string, bod
 		if readErr != nil {
 			return readErr
 		}
+
+		// Limit the size of the error message body to avoid excessive logs
+		if len(bodyBytes) > 500 {
+			bodyBytes = bodyBytes[:500]
+		}
+
 		return fmt.Errorf("server response %s: %s", path, string(bodyBytes))
 	}
 

--- a/internal/provider/data_source_org_members_test.go
+++ b/internal/provider/data_source_org_members_test.go
@@ -53,3 +53,19 @@ output "self" {
 }
 `, orgName, username)
 }
+
+func TestAccOrgMembersDataSourceLargeOrg(t *testing.T) {
+	username := os.Getenv("DOCKER_USERNAME")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrgMembersDataSourceConfig("docker", username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("self", username),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_org_team_member.go
+++ b/internal/provider/data_source_org_team_member.go
@@ -204,7 +204,7 @@ func (d *OrgTeamMemberDataSource) Read(ctx context.Context, req datasource.ReadR
 	}
 
 	var memberList []Member
-	for _, member := range members.Results {
+	for _, member := range members {
 		memberGroups := make([]attr.Value, len(member.Groups))
 		for i, group := range member.Groups {
 			memberGroups[i] = types.StringValue(group)

--- a/internal/provider/resource_org_team_member.go
+++ b/internal/provider/resource_org_team_member.go
@@ -158,7 +158,7 @@ func (r *OrgTeamMemberResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	// Call the new API to list members of the team
-	membersResponse, err := r.client.ListOrgTeamMembers(ctx, data.OrgName.ValueString(), data.TeamName.ValueString())
+	members, err := r.client.ListOrgTeamMembers(ctx, data.OrgName.ValueString(), data.TeamName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to read org_team_member resource", fmt.Sprintf("Error retrieving team members: %v", err))
 		return
@@ -166,7 +166,7 @@ func (r *OrgTeamMemberResource) Read(ctx context.Context, req resource.ReadReque
 
 	// Check if the specified user is in the team
 	found := false
-	for _, member := range membersResponse.Results {
+	for _, member := range members {
 		if member.Username == data.UserName.ValueString() {
 			found = true
 			break


### PR DESCRIPTION
- update org client to use common pagination helper
- when a request fails, don't print the full
  request body. just the first 500 chars.
  otherwise it's a bit overwhelming.
- add an acceptance test for an org that
  requires pagination

this was useful when i was investigating
https://github.com/docker/terraform-provider-docker/issues/117

Signed-off-by: Nick Santos <nick.santos@docker.com>
