### PR TITLE
ci: pin docker/login-action to commit SHA

### DIFF
--- a/.github/workflows/acctest.yaml
+++ b/.github/workflows/acctest.yaml
@@ -39,7 +39,7 @@ jobs:
           terraform_version: ${{ inputs.terraform-version }}
           terraform_wrapper: false
 
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
## Summary

Pin `docker/login-action` to a full-length commit SHA in `acctest.yaml` to comply with the repository's action pinning policy.

Fixes the acceptance test workflow which was failing with:
```
The action docker/login-action@v2 is not allowed because all actions must be pinned to a full-length commit SHA.
```