### PR TITLE
fix: use planned team name after rename to avoid inconsistent state

### DIFF
--- a/internal/provider/resource_org_team.go
+++ b/internal/provider/resource_org_team.go
@@ -209,7 +209,8 @@ func (r *OrgTeamResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	data.ID = types.Int64Value(orgTeam.ID)
-	data.TeamName = types.StringValue(orgTeam.Name)
+	// Use the planned team name rather than the API response, which returns the
+	// old name before the rename takes effect.
 	if len(orgTeam.Description) > 0 {
 		data.TeamDesc = types.StringValue(orgTeam.Description)
 	} else {


### PR DESCRIPTION
## Summary

The `PATCH /orgs/{org}/groups/{name}/` API returns the team with the old name before the rename takes effect. The `Update` function was setting `data.TeamName` from this stale response, causing Terraform's post-apply consistency check to see a diff between the old name in state and the new name in config.

This produced an `"inconsistent result after apply"` error on every `docker_org_team` rename.

## Fix

Drop the `data.TeamName = types.StringValue(orgTeam.Name)` line in `Update`. `data` is already populated from `req.Plan` with the correct new name — no need to override it from the API response.