### PR TITLE
tests: add OAT acceptance tests for RAM and org members

### DIFF
--- a/.github/workflows/acctest.yaml
+++ b/.github/workflows/acctest.yaml
@@ -50,5 +50,6 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
           DOCKER_HUB_HOST: "hub-stage.docker.com"
+          DOCKER_OAT: ${{ secrets.DOCKER_OAT }}
           TF_ACC: "1"
         timeout-minutes: 30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,15 @@ export DOCKER_PASSWORD=[your-password]
 export ACCTEST_DOCKER_ORG=[an-org-you-belong-to]
 ```
 
+To run OAT-specific tests (those testing Organization Access Token authentication),
+also set `DOCKER_OAT` to an OAT issued for the org in `ACCTEST_DOCKER_ORG`. The OAT
+needs the scopes required by the resources under test (e.g. RAM Read/Write, Member Read).
+OAT tests are automatically skipped when `DOCKER_OAT` is not set.
+
+```
+export DOCKER_OAT=[your-oat]
+```
+
 Then run:
 
 ```
@@ -109,13 +118,14 @@ To run it on a specific branch, run:
 gh workflow run acctest.yaml -f ref=[git-sha|branch-name]
 ```
 
-To run it locally, you will need credentials for our test account. 
-The password is in the terraform-provider-docker 1password vault.
+To run it locally, you will need credentials for our internal test account.
+The password and OAT are in the terraform-provider-docker 1password vault.
 
 ```
 export DOCKER_HUB_HOST=hub-stage.docker.com
 export DOCKER_USERNAME=dockerterraformacctest
 export DOCKER_PASSWORD=[password]
+export DOCKER_OAT=[oat]
 make testacc
 ```
 

--- a/internal/provider/data_source_org_members_test.go
+++ b/internal/provider/data_source_org_members_test.go
@@ -54,6 +54,35 @@ output "self" {
 `, orgName, username)
 }
 
+func TestAccOrgMembersDataSourceOAT(t *testing.T) {
+	oat := os.Getenv("DOCKER_OAT")
+	if oat == "" {
+		t.Skip("DOCKER_OAT not set, skipping OAT acceptance test")
+	}
+	orgName := envvar.GetWithDefault(envvar.AccTestOrganization)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrgSettingRegistryAccessManagementOATProvider(orgName, oat) +
+					testAccOrgMembersDataSourceOATConfig(orgName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.docker_org_members._", "members.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOrgMembersDataSourceOATConfig(orgName string) string {
+	return fmt.Sprintf(`
+data "docker_org_members" "_" {
+  org_name = "%s"
+}
+`, orgName)
+}
+
 func TestAccOrgMembersDataSourceLargeOrg(t *testing.T) {
 	username := os.Getenv("DOCKER_USERNAME")
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_org_setting_registry_access_management_test.go
+++ b/internal/provider/resource_org_setting_registry_access_management_test.go
@@ -18,12 +18,55 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/docker/terraform-provider-docker/internal/envvar"
 	"github.com/docker/terraform-provider-docker/internal/hubclient"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestAccOrgSettingRegistryAccessManagementOAT(t *testing.T) {
+	oat := os.Getenv("DOCKER_OAT")
+	if oat == "" {
+		t.Skip("DOCKER_OAT not set, skipping OAT acceptance test")
+	}
+	orgName := envvar.GetWithDefault(envvar.AccTestOrganization)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOrgSettingRegistryAccessManagementOATProvider(orgName, oat) +
+					testAccOrgSettingRegistryAccessManagementNoCustomRegistry(orgName, true, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("docker_org_setting_registry_access_management.test", "org_name", orgName),
+					resource.TestCheckResourceAttr("docker_org_setting_registry_access_management.test", "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccOrgSettingRegistryAccessManagementOATProvider(orgName, oat) +
+					testAccOrgSettingRegistryAccessManagementNoCustomRegistry(orgName, false, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("docker_org_setting_registry_access_management.test", "org_name", orgName),
+					resource.TestCheckResourceAttr("docker_org_setting_registry_access_management.test", "enabled", "false"),
+				),
+			},
+			{
+				Config: testAccOrgSettingRegistryAccessManagementOATProvider(orgName, oat),
+			},
+		},
+	})
+}
+
+func testAccOrgSettingRegistryAccessManagementOATProvider(orgName, oat string) string {
+	return fmt.Sprintf(`
+provider "docker" {
+  username = %q
+  password = %q
+}
+`, orgName, oat)
+}
 
 func TestAccOrgSettingRegistryAccessManagement(t *testing.T) {
 	orgName := envvar.GetWithDefault(envvar.AccTestOrganization)


### PR DESCRIPTION
## Summary

- Adds `TestAccOrgSettingRegistryAccessManagementOAT`: verifies that an Organization Access Token (OAT) can authenticate and manage Registry Access Management settings end-to-end
- Adds `TestAccOrgMembersDataSourceOAT`: verifies that an OAT can authenticate and list org members
- Both tests configure the provider with explicit `username` (org name) and `password` (OAT) in the provider block, bypassing the credential store
- Both tests skip automatically when `DOCKER_OAT` is not set, so they are non-blocking for contributors without an OAT
- Passes `DOCKER_OAT` secret through in `acctest.yaml` for CI runs
- Updates `CONTRIBUTING.md` with OAT testing instructions for external contributors and internal team