### PR TITLE
ci: restrict GITHUB_TOKEN permissions to contents: read

### DIFF
--- a/.github/workflows/acctest.yaml
+++ b/.github/workflows/acctest.yaml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     concurrency: acctest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
## Summary

Fixes two medium-severity code scanning alerts for unrestricted `GITHUB_TOKEN` scope:

- Adds `permissions: contents: read` to the `build` job in `ci.yaml`
- Adds `permissions: contents: read` to the `acctest` job in `acctest.yaml`

Both jobs only need read access to repository contents. Following the principle of least privilege reduces the blast radius if a third-party action in either workflow is compromised.